### PR TITLE
Integrates xspecies results using mikado

### DIFF
--- a/annotation/__main__.py
+++ b/annotation/__main__.py
@@ -368,6 +368,13 @@ def parse_arguments():
                              nargs='+',
                              help="Filter annotation coding genes by the filter types specified",
                              default=['none'])
+    homology_ap.add_argument("--junctions", type=argparse.FileType('r'),
+                             help="Validated junctions BED file for use in Mikado consolidation stage.")
+    homology_ap.add_argument("--utrs", type=argparse.FileType('r'),
+                             help="Gene models that may provide UTR extensions to the homology based models at the "
+                                  "mikado stage")
+    homology_ap.add_argument("--pick_extra_config", type=argparse.FileType('r'),
+                             help="Extra configuration for Mikado pick stage")
     homology_ap.add_argument("--filter_min_cds", type=int,
                              help="If 'aa_len' filter is enabled for annotation coding features, any CDS smaller than"
                                   "this parameter will be filtered out",
@@ -913,6 +920,13 @@ def combine_arguments_homology(cli_arguments):
     cromwell_inputs["ei_homology.AlignProteins.species"] = cli_arguments.alignment_species
 
     # Optional extra parameters
+    if cli_arguments.pick_extra_config:
+        cromwell_inputs['ei_homology.MikadoPick.extra_config'] = cli_arguments.pick_extra_config
+    if cli_arguments.junctions:
+        cromwell_inputs['ei_homology.Mikado.junctions'] = cli_arguments.junctions
+    if cli_arguments.utrs:
+        cromwell_inputs['ei_homology.Mikado.utrs'] = cli_arguments.utrs
+
     if cli_arguments.junction_f1_filter:
         cromwell_inputs["ei_homology.CombineResults.junction_f1_filter"] = cli_arguments.junction_f1_filter
     if cli_arguments.exon_f1_filter:

--- a/annotation/__main__.py
+++ b/annotation/__main__.py
@@ -928,16 +928,16 @@ def combine_arguments_homology(cli_arguments):
 
     cromwell_inputs["ei_homology.genome_to_annotate"] = cli_arguments.genome.name
     cromwell_inputs["ei_homology.AlignProteins.species"] = cli_arguments.alignment_species
-    cromwell_inputs["ei_homology.mikado_config"] = cli_arguments.mikado_config
-    cromwell_inputs["ei_homology.mikado_scoring"] = cli_arguments.mikado_scoring
+    cromwell_inputs["ei_homology.mikado_config"] = cli_arguments.mikado_config.name
+    cromwell_inputs["ei_homology.mikado_scoring"] = cli_arguments.mikado_scoring.name
 
     # Optional extra parameters
     if cli_arguments.pick_extra_config:
-        cromwell_inputs['ei_homology.MikadoPick.extra_config'] = cli_arguments.pick_extra_config
+        cromwell_inputs['ei_homology.MikadoPick.extra_config'] = cli_arguments.pick_extra_config.name
     if cli_arguments.junctions:
-        cromwell_inputs['ei_homology.Mikado.junctions'] = cli_arguments.junctions
+        cromwell_inputs['ei_homology.Mikado.junctions'] = cli_arguments.junctions.name
     if cli_arguments.utrs:
-        cromwell_inputs['ei_homology.Mikado.utrs'] = cli_arguments.utrs
+        cromwell_inputs['ei_homology.Mikado.utrs'] = cli_arguments.utrs.name
     if cli_arguments.min_cdna_length:
         cromwell_inputs["ei_homology.Mikado.min_cdna_length"] = cli_arguments.min_cdna_length
     if cli_arguments.max_intron_length:

--- a/annotation/__main__.py
+++ b/annotation/__main__.py
@@ -368,6 +368,12 @@ def parse_arguments():
                              nargs='+',
                              help="Filter annotation coding genes by the filter types specified",
                              default=['none'])
+    homology_ap.add_argument("--mikado_config", type=argparse.FileType('r'),
+                             help="Base configuration for Mikado consolidation stage.",
+                             required=True)
+    homology_ap.add_argument("--mikado_scoring", type=argparse.FileType('r'),
+                             help="Scoring file for Mikado pick at consolidation stage.",
+                             required=True)
     homology_ap.add_argument("--junctions", type=argparse.FileType('r'),
                              help="Validated junctions BED file for use in Mikado consolidation stage.")
     homology_ap.add_argument("--utrs", type=argparse.FileType('r'),
@@ -375,6 +381,10 @@ def parse_arguments():
                                   "mikado stage")
     homology_ap.add_argument("--pick_extra_config", type=argparse.FileType('r'),
                              help="Extra configuration for Mikado pick stage")
+    homology_ap.add_argument("--min_cdna_length", type=int, default=100,
+                             help="Minimum cdna length for models to consider in Mikado consolidation stage")
+    homology_ap.add_argument("--max_intron_length", type=int, default=1000000,
+                             help="Maximum intron length for models to consider in Mikado consolidation stage")
     homology_ap.add_argument("--filter_min_cds", type=int,
                              help="If 'aa_len' filter is enabled for annotation coding features, any CDS smaller than"
                                   "this parameter will be filtered out",
@@ -918,6 +928,8 @@ def combine_arguments_homology(cli_arguments):
 
     cromwell_inputs["ei_homology.genome_to_annotate"] = cli_arguments.genome.name
     cromwell_inputs["ei_homology.AlignProteins.species"] = cli_arguments.alignment_species
+    cromwell_inputs["ei_homology.mikado_config"] = cli_arguments.mikado_config
+    cromwell_inputs["ei_homology.mikado_scoring"] = cli_arguments.mikado_scoring
 
     # Optional extra parameters
     if cli_arguments.pick_extra_config:
@@ -926,6 +938,10 @@ def combine_arguments_homology(cli_arguments):
         cromwell_inputs['ei_homology.Mikado.junctions'] = cli_arguments.junctions
     if cli_arguments.utrs:
         cromwell_inputs['ei_homology.Mikado.utrs'] = cli_arguments.utrs
+    if cli_arguments.min_cdna_length:
+        cromwell_inputs["ei_homology.Mikado.min_cdna_length"] = cli_arguments.min_cdna_length
+    if cli_arguments.max_intron_length:
+        cromwell_inputs["ei_homology.Mikado.max_intron_length"] = cli_arguments.max_intron_length
 
     if cli_arguments.junction_f1_filter:
         cromwell_inputs["ei_homology.CombineResults.junction_f1_filter"] = cli_arguments.junction_f1_filter

--- a/annotation/homology_module/main.wdl
+++ b/annotation/homology_module/main.wdl
@@ -129,7 +129,7 @@ task Mikado {
         Int min_cdna_length = 100
         Int max_intron_length = 1000000
         Array[File] xspecies
-        Array[File]? utrs
+        File? utrs
         File? junctions
         String output_prefix
     }
@@ -153,13 +153,13 @@ task Mikado {
         echo -e "${i}\t${label}\tTrue\t1\tTrue" >> list.txt
         done
 
-        if [ "" != "~{sep=" " utrs}" ]
+        if [ "" != "~{utrs}" ]
         then
-            for i in ~{sep=" " utrs}
-            do
+#            for i in ~{sep=" " utrs}
+#            do
                 label="UTRs"
-                echo -e "${i}\t${label}\tTrue\t0\tFalse" >> list.txt
-            done
+                echo -e "~{utrs}\t${label}\tTrue\t0\tFalse" >> list.txt
+#            done
         fi
 
         # mikado configure

--- a/annotation/homology_module/main.wdl
+++ b/annotation/homology_module/main.wdl
@@ -153,8 +153,11 @@ task Mikado {
         echo -e "${i}\t${label}\tTrue\t1\tTrue" >> list.txt
         done
 
+        apply_pad="--no-pad "
+
         if [ "" != "~{utrs}" ]
         then
+             apply_pad=""
 #            for i in ~{sep=" " utrs}
 #            do
                 label="UTRs"
@@ -163,7 +166,7 @@ task Mikado {
         fi
 
         # mikado configure
-        mikado configure --only-reference-update --check-references --reference-update \
+        mikado configure $apply_pad --only-reference-update --check-references --reference-update \
         --max-intron-length ~{max_intron_length} --minimum-cdna-length ~{min_cdna_length} \
         --reference ~{reference} --list=list.txt --copy-scoring plant.yaml original-mikado.yaml
 

--- a/annotation/homology_module/main.wdl
+++ b/annotation/homology_module/main.wdl
@@ -115,6 +115,10 @@ workflow ei_homology {
         Array[File] annotation_filter_stats = PrepareAnnotations.stats
         Array[File] alignment_filter_stats = AlignProteins.stats
         File        mgc_score_summary = ScoreSummary.summary_table
+        File loci = MikadoPick.loci
+        File scores = MikadoPick.scores
+        File metrics = MikadoPick.metrics
+        File stats = MikadoPick.stats
     }
 }
 

--- a/annotation/homology_module/main.wdl
+++ b/annotation/homology_module/main.wdl
@@ -168,7 +168,7 @@ task Mikado {
         mikado prepare --procs=~{task_cpus} --json-conf ~{output_prefix}-mikado.yaml -od ~{output_prefix}-mikado
 
         # mikado serialise
-        mikado serialise ~{"--junctions " + junctions} --transcripts ~{output_prefix}-mikado/mikado_prepared.fasta \
+        mikado serialise --force ~{"--junctions " + junctions} --transcripts ~{output_prefix}-mikado/mikado_prepared.fasta \
         --json-conf=~{output_prefix}-mikado.yaml --start-method=spawn -od ~{output_prefix}-mikado --procs=~{task_cpus}
 
     >>>

--- a/annotation/homology_module/main.wdl
+++ b/annotation/homology_module/main.wdl
@@ -142,14 +142,17 @@ task Mikado {
     command <<<
         set -euxo pipefail
         # Create the lists file
-        for i in ~{sep=" " xspecies} do
-            label=`basename ${i} | cut -d. -f1`
-            echo -e "${i}\t${label}\tTrue\t1\tTrue" >> list.txt
+        for i in ~{sep=" " xspecies}
+        do
+        bname=basename ${i}
+        label=${bname%%.*}
+        echo -e "${i}\t${label}\tTrue\t1\tTrue" >> list.txt
         done
 
         if [ "" != "~{sep=" " utrs}" ]
         then
-            for i in ~{sep=" " utrs} do
+            for i in ~{sep=" " utrs}
+            do
                 label="UTRs"
                 echo -e "${i}\t${label}\tTrue\t0\tFalse" >> list.txt
             done
@@ -165,8 +168,8 @@ task Mikado {
         mikado prepare --procs=~{task_cpus} --json-conf ~{output_prefix}-mikado.yaml -od ~{output_prefix}-mikado
 
         # mikado serialise
-        mikado serialise ~{"--junctions " + junctions} --transcripts ~{output_prefix}-mikado/mikado_prepared.fasta
-        --json-conf=~{output_prefix}-mikado.yaml --start-method=spawn -od mikado --procs=~{task_cpus}
+        mikado serialise ~{"--junctions " + junctions} --transcripts ~{output_prefix}-mikado/mikado_prepared.fasta \
+        --json-conf=~{output_prefix}-mikado.yaml --start-method=spawn -od ~{output_prefix}-mikado --procs=~{task_cpus}
 
     >>>
 }

--- a/annotation/homology_module/main.wdl
+++ b/annotation/homology_module/main.wdl
@@ -144,7 +144,7 @@ task Mikado {
         # Create the lists file
         for i in ~{sep=" " xspecies}
         do
-        bname=basename ${i}
+        bname=$(basename ${i})
         label=${bname%%.*}
         echo -e "${i}\t${label}\tTrue\t1\tTrue" >> list.txt
         done

--- a/annotation/homology_module/main.wdl
+++ b/annotation/homology_module/main.wdl
@@ -143,14 +143,14 @@ task Mikado {
         set -euxo pipefail
         # Create the lists file
         for i in ~{sep=" " xspecies} do
-            label = echo ${i} | cut -d. -f1
+            label=`basename ${i} | cut -d. -f1`
             echo -e "${i}\t${label}\tTrue\t1\tTrue" >> list.txt
         done
 
         if [ "" != "~{sep=" " utrs}" ]
         then
             for i in ~{sep=" " utrs} do
-                label = "UTRs"
+                label="UTRs"
                 echo -e "${i}\t${label}\tTrue\t0\tFalse" >> list.txt
             done
         fi

--- a/annotation/homology_module/main.wdl
+++ b/annotation/homology_module/main.wdl
@@ -163,7 +163,8 @@ task Mikado {
         fi
 
         # mikado configure
-        mikado configure --max-intron-length ~{max_intron_length} --minimum-cdna-length ~{min_cdna_length} \
+        mikado configure --only-reference-update --check-references --reference-update \
+        --max-intron-length ~{max_intron_length} --minimum-cdna-length ~{min_cdna_length} \
         --reference ~{reference} --list=list.txt --copy-scoring plant.yaml original-mikado.yaml
 
         yaml-merge -s original-mikado.yaml ~{"-m " + extra_config} -o ~{output_prefix}-mikado.yaml

--- a/annotation/homology_module/main.wdl
+++ b/annotation/homology_module/main.wdl
@@ -17,10 +17,6 @@ workflow ei_homology {
         Array[GenomeAnnotation] annotations
         File genome_to_annotate
         File mikado_scoring
-        File mikado_config
-        File? mikado_pick_extra_config
-        File? mikado_junctions
-        Array[File]? mikado_utr
         RuntimeAttr? index_attr
         RuntimeAttr? score_attr
         RuntimeAttr? aln_attr
@@ -96,16 +92,12 @@ workflow ei_homology {
         input:
         reference = genome_to_annotate,
         xspecies = CombineXspecies.xspecies_scored_alignment,
-        utrs = mikado_utr,
-        junctions = mikado_junctions,
-        config = mikado_config,
         output_prefix = "xspecies"
     }
 
     call MikadoPick {
         input:
         config_file = Mikado.mikado_config,
-        extra_config = mikado_pick_extra_config,
         scoring_file = mikado_scoring,
         mikado_db = Mikado.mikado_db,
         transcripts = Mikado.prepared_gtf,
@@ -128,7 +120,6 @@ task Mikado {
     input {
         File reference
         Array[File] xspecies
-        File config
         Array[File]? utrs
         File? junctions
         String output_prefix

--- a/annotation/homology_module/main.wdl
+++ b/annotation/homology_module/main.wdl
@@ -75,7 +75,7 @@ workflow ei_homology {
 
     call ScoreSummary {
         input:
-        alignments = ScoreAlignments.alignment_compare
+        alignments_detail = ScoreAlignments.alignment_compare_detail
     }
 
     scatter (alignment in CombineResults.augmented_alignments_gff) {
@@ -211,7 +211,7 @@ task MikadoPick {
 
 task ScoreSummary {
     input {
-        Array[File] alignments
+        Array[File] alignments_detail
     }
 
     output {
@@ -222,7 +222,7 @@ task ScoreSummary {
         set -euxo pipefail
         mkdir ScoreAlignments
         cd ScoreAlignments
-        for i in ../comp*[^detail].tab; do
+        for i in ~{sep=" " alignments_detail}; do
             echo $i;
             cat $i |awk -vOFS=" " 'NR > 1 {print $11,$13}' |awk '{sum = 0; for (i = 1; i <= NF; i++) sum += $i; sum /= NF; print sum}' | \
             awk 'BEGIN { delta = (delta == "" ? 0.1 : delta) }


### PR DESCRIPTION
Allows integration of the homology derived models using mikado

This integration requires using mikado's `check-references`, `reference-update`, `only-reference-update` options, a custom scoring file that makes use of external metrics and any other custom configuration parameters the user might want to apply from a file.

Similarly, a user can optionally incorporate a valid set of junctions to validate and score splicing or models with UTRs which will extend UTRs of the homology derived models when possible.