### PR TITLE
Better control for non best scoring transcripts

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Install dependencies
       run: |
         wget -q -O cromwell.jar https://github.com/broadinstitute/cromwell/releases/download/63/cromwell-63.jar
-        pip install pytest-workflow
+        pip install pytest==6.2.5 pytest-workflow
         pip install .
         reat --help
     - name: CLI test

--- a/annotation/scripts/classify_transcripts
+++ b/annotation/scripts/classify_transcripts
@@ -327,11 +327,11 @@ def main():
                 txct.combined_cds_fraction >= min_pct_cds_fraction  # The cDNA is not twice as long as the CDS (indicating too much UTR)
         )
         category = TRANSCRIPT_CLASS[STONE]
-        if fl_category == FL_CATEGORY[COMPLETE] and txct_reqs:
+        if (fl_category == FL_CATEGORY[COMPLETE] or fl_category == FL_CATEGORY[PUTATIVE]) and txct_reqs:
             category = TRANSCRIPT_CLASS[GOLD]
         elif txct_reqs and txct.selected_cds_length >= 900:
             category = TRANSCRIPT_CLASS[SILVER]
-        elif fl_category == FL_CATEGORY[COMPLETE]:
+        elif fl_category == FL_CATEGORY[COMPLETE] or fl_category == FL_CATEGORY[PUTATIVE]:
             category = TRANSCRIPT_CLASS[BRONZE]
         gdfl.append((txct.chrom, txct.strand, txct.start, txct.end, g[0], fl_category,
                      category, txct.attributes['locus'], score))


### PR DESCRIPTION
Classifies as GOLD 'PUTATIVE' full length transcripts, i.e. transcripts that do not obtain the best possible score due to minor mismatches that do not break any of the hard limits, whilst still meeting the transcript requirements in terms of UTRs and CDS fraction.

Also, 'PUTATIVE' transcripts that do not meet the transcript requirements nor were classified as 'SILVER' are now classified as 'BRONZE' instead of 'STONE'.

This should prevent the issue where any minor missmatch prevented transcripts from being classified as 'GOLD' whilst allowing the 'hard filters' better control over what can end up in the 'GOLD' category.

Fixes #21